### PR TITLE
Fix hint type

### DIFF
--- a/pypep/client.py
+++ b/pypep/client.py
@@ -125,12 +125,12 @@ class Pasargad(object):
 
     # Generate Redirect Address for payment ====================================
     def redirect(self, amount, invoice_number, invoice_date, mobile='', email=''):
-        # type: (str, str, str, str, str) -> dict
+        # type: (str, str, str, str, str) -> str
         """
         Generate Payment URL 
         :param amount: Invoice amount
         :param invoice_number: invoice number
-        :param invoice_date: Invoice date in format of "Y/m/d H:i:s"
+        :param invoice_date: Invoice date in format of "Y/m/d H:M:S"
         :param mobile: optional - invoice owner mobile number
         :param email:  optional - invoice owner email address
         :return: str 


### PR DESCRIPTION
fix type hint return type and invoice_date date format according to the provided example in Readme and python date time formatting standard.
M Minute as a zero-padded decimal number. ex: 00, 01, ..., 59
S Second as a zero-padded decimal number. ex: 00, 01, ..., 59